### PR TITLE
feat: harden module configuration and add test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Validate configuration
         run: make validate
 
+      - name: Run tests
+        run: make test
+
   github-actions-workflows:
 
     name: GitHub Actions

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,10 @@ fmt-check:
 validate:
 	terraform validate
 
+.PHONY: test
+test:
+	terraform test
+
 .PHONY: lint-init
 lint-init:
 	tflint --init

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ sequenceDiagram
 | name_prefix | The name prefix used for the resources created by this module. | `string` | n/a | yes |
 | read_policy_document | The IAM policy document for the reader role assumed from non-trunk branch workflows. | ```object({ Version = string Statement = list(object({ Effect = string Action = list(string) Resource = string })) })``` | n/a | yes |
 | tfstate_config | The Terraform state backend configuration, to which the provider will provide access. | ```object({ bucket_name = string state_files = list(string) })``` | n/a | yes |
+| max_session_duration | The maximum session duration (in seconds) for the admin and reader roles. | `number` | `3600` | no |
+| tags | A map of tags to apply to all resources created by this module. | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 locals {
   repo_with_owner = "${var.github.owner}/${var.github.repo}"
   audience        = format("sts.%v", data.aws_partition.this.dns_suffix)
+  bucket_arn      = "arn:${data.aws_partition.this.partition}:s3:::${var.tfstate_config.bucket_name}"
 }
 
 
@@ -13,6 +14,7 @@ resource "aws_iam_openid_connect_provider" "github" {
   client_id_list  = ["https://github.com/${var.github.owner}", local.audience]
   thumbprint_list = toset([data.tls_certificate.github.certificates[0].sha1_fingerprint])
   url             = "https://token.actions.githubusercontent.com"
+  tags            = var.tags
 }
 
 #
@@ -24,13 +26,14 @@ resource "aws_iam_openid_connect_provider" "github" {
 resource "aws_iam_policy" "terraform_state_management" {
   name        = "gha-${var.name_prefix}-tfstate-mgmt"
   description = "Permissions required to manage the Terraform S3 backend state and lockfile."
+  tags        = var.tags
   policy = jsonencode({
     Version = "2012-10-17",
     Statement = [
       {
         Effect   = "Allow",
         Action   = "s3:ListBucket",
-        Resource = "arn:aws:s3:::${var.tfstate_config.bucket_name}",
+        Resource = local.bucket_arn,
         Condition = {
           StringLike = {
             "s3:prefix" = [
@@ -47,7 +50,7 @@ resource "aws_iam_policy" "terraform_state_management" {
         ],
         Resource = [
           for state_file in var.tfstate_config.state_files :
-          "arn:aws:s3:::${var.tfstate_config.bucket_name}/${state_file}"
+          "${local.bucket_arn}/${state_file}"
         ]
 
       },
@@ -60,7 +63,7 @@ resource "aws_iam_policy" "terraform_state_management" {
         ],
         Resource = [
           for state_file in var.tfstate_config.state_files :
-          "arn:aws:s3:::${var.tfstate_config.bucket_name}/${state_file}.tflock"
+          "${local.bucket_arn}/${state_file}.tflock"
         ]
       }
     ]
@@ -76,7 +79,8 @@ resource "aws_iam_policy" "terraform_state_management" {
 resource "aws_iam_role" "admin" {
   name                 = "gha-${var.name_prefix}-admin"
   description          = "Full access for trunk branch deployment"
-  max_session_duration = 3600
+  max_session_duration = var.max_session_duration
+  tags                 = var.tags
   assume_role_policy = jsonencode({
     Version = "2012-10-17",
     Statement = [
@@ -119,7 +123,8 @@ resource "aws_iam_role_policy" "admin" {
 resource "aws_iam_role" "read" {
   name                 = "gha-${var.name_prefix}-read"
   description          = "Read-only access for non-trunk branches"
-  max_session_duration = 3600
+  max_session_duration = var.max_session_duration
+  tags                 = var.tags
   assume_role_policy = jsonencode({
     Version = "2012-10-17",
     Statement = [

--- a/tests/oidc.tftest.hcl
+++ b/tests/oidc.tftest.hcl
@@ -1,0 +1,134 @@
+# Native `terraform test` suite. Uses mock providers so it runs with no AWS
+# credentials and produces no real infrastructure. Run with `make test`.
+
+mock_provider "aws" {
+  mock_data "aws_partition" {
+    defaults = {
+      partition  = "aws"
+      dns_suffix = "amazonaws.com"
+    }
+  }
+
+  mock_resource "aws_iam_policy" {
+    defaults = {
+      arn = "arn:aws:iam::123456789012:policy/mock"
+    }
+  }
+}
+
+mock_provider "tls" {
+  mock_data "tls_certificate" {
+    defaults = {
+      certificates = [
+        { sha1_fingerprint = "1111111111111111111111111111111111111111" },
+        { sha1_fingerprint = "2222222222222222222222222222222222222222" },
+      ]
+    }
+  }
+}
+
+variables {
+  name_prefix = "demo-app"
+  github = {
+    owner        = "example-org"
+    repo         = "demo-repo"
+    trunk_branch = "main"
+  }
+  tfstate_config = {
+    bucket_name = "example-tfstate-bucket"
+    state_files = ["terraform/demo-app/terraform.tfstate"]
+  }
+  read_policy_document = {
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["s3:GetObject"]
+      Resource = "arn:aws:s3:::example-data-bucket/*"
+    }]
+  }
+  admin_policy_document = {
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["s3:GetObject", "s3:PutObject"]
+      Resource = "arn:aws:s3:::example-data-bucket/*"
+    }]
+  }
+}
+
+run "creates_prefixed_roles" {
+  command = plan
+
+  assert {
+    condition     = aws_iam_role.admin.name == "gha-demo-app-admin"
+    error_message = "Admin role name should be prefixed with gha-<name_prefix>."
+  }
+
+  assert {
+    condition     = aws_iam_role.read.name == "gha-demo-app-read"
+    error_message = "Reader role name should be prefixed with gha-<name_prefix>."
+  }
+
+  assert {
+    condition     = aws_iam_policy.terraform_state_management.name == "gha-demo-app-tfstate-mgmt"
+    error_message = "State-management policy name should be prefixed with gha-<name_prefix>."
+  }
+}
+
+run "registers_oidc_thumbprint" {
+  command = plan
+
+  assert {
+    condition     = length(aws_iam_openid_connect_provider.github.thumbprint_list) == 1
+    error_message = "The OIDC provider should register the leaf certificate thumbprint."
+  }
+}
+
+run "trunk_branch_can_only_assume_admin_role" {
+  # apply (against mocks) so the provider-normalized trust policy is resolved.
+  command = apply
+
+  # The admin trust policy must be scoped to the trunk branch ref.
+  assert {
+    condition     = strcontains(aws_iam_role.admin.assume_role_policy, "repo:example-org/demo-repo:ref:refs/heads/main")
+    error_message = "Admin role trust policy must be scoped to the trunk branch."
+  }
+
+  # The reader trust policy must explicitly exclude the trunk branch.
+  assert {
+    condition     = strcontains(aws_iam_role.read.assume_role_policy, "StringNotLike")
+    error_message = "Reader role must exclude the trunk branch via StringNotLike."
+  }
+}
+
+run "default_session_duration_is_one_hour" {
+  command = plan
+
+  assert {
+    condition     = aws_iam_role.admin.max_session_duration == 3600
+    error_message = "Default max_session_duration should be 3600 seconds."
+  }
+}
+
+run "rejects_name_prefix_exceeding_iam_role_limit" {
+  command = plan
+
+  variables {
+    name_prefix = "this-name-prefix-is-far-too-long-to-fit-within-the-iam-role-name-limit"
+  }
+
+  expect_failures = [var.name_prefix]
+}
+
+run "rejects_empty_state_files" {
+  command = plan
+
+  variables {
+    tfstate_config = {
+      bucket_name = "example-tfstate-bucket"
+      state_files = []
+    }
+  }
+
+  expect_failures = [var.tfstate_config]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -5,6 +5,11 @@ variable "github" {
     repo         = string
     trunk_branch = string
   })
+
+  validation {
+    condition     = length(var.github.owner) > 0 && length(var.github.repo) > 0 && length(var.github.trunk_branch) > 0
+    error_message = "github.owner, github.repo and github.trunk_branch must all be non-empty."
+  }
 }
 
 variable "tfstate_config" {
@@ -13,12 +18,28 @@ variable "tfstate_config" {
     bucket_name = string
     state_files = list(string)
   })
+
+  validation {
+    condition     = length(var.tfstate_config.bucket_name) >= 3 && length(var.tfstate_config.bucket_name) <= 63
+    error_message = "tfstate_config.bucket_name must be a valid S3 bucket name (3-63 characters)."
+  }
+
+  validation {
+    condition     = length(var.tfstate_config.state_files) > 0
+    error_message = "tfstate_config.state_files must contain at least one state file path."
+  }
 }
 
 
 variable "name_prefix" {
   description = "The name prefix used for the resources created by this module."
   type        = string
+
+  validation {
+    # "gha-<name_prefix>-admin" must stay within the 64-character IAM role name limit.
+    condition     = can(regex("^[a-zA-Z0-9-]+$", var.name_prefix)) && length(var.name_prefix) <= 54
+    error_message = "name_prefix must contain only alphanumeric characters and hyphens, and be at most 54 characters."
+  }
 }
 
 variable "read_policy_document" {
@@ -43,4 +64,21 @@ variable "admin_policy_document" {
       Resource = string
     }))
   })
+}
+
+variable "max_session_duration" {
+  description = "The maximum session duration (in seconds) for the admin and reader roles."
+  type        = number
+  default     = 3600
+
+  validation {
+    condition     = var.max_session_duration >= 3600 && var.max_session_duration <= 43200
+    error_message = "max_session_duration must be between 3600 and 43200 seconds (AWS IAM limits)."
+  }
+}
+
+variable "tags" {
+  description = "A map of tags to apply to all resources created by this module."
+  type        = map(string)
+  default     = {}
 }


### PR DESCRIPTION
## Robustness
- Derive the S3 ARN partition from the provider instead of hardcoding `aws`
- Validate `name_prefix`, `github` and `tfstate_config` inputs

## Configurability
- Add optional `tags` variable applied to all resources
- Add configurable `max_session_duration` (default 3600)

## Testability
- Add mock-provider `terraform test` suite (no AWS credentials, no real infra)
- Run tests via `make test` in CI

All changes are backward compatible; consumers need no changes.
